### PR TITLE
Set up type-safe navigation infrastructure #10

### DIFF
--- a/app/src/main/java/com/goldennova/upquest/MainActivity.kt
+++ b/app/src/main/java/com/goldennova/upquest/MainActivity.kt
@@ -6,12 +6,10 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.goldennova.upquest.presentation.navigation.AppNavHost
 import com.goldennova.upquest.presentation.theme.UpQuestTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -26,12 +24,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
             UpQuestTheme(themeMode = themeMode) {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Text(
-                        text = "UpQuest",
-                        modifier = Modifier.padding(innerPadding),
-                    )
-                }
+                AppNavHost(modifier = Modifier.fillMaxSize())
             }
         }
     }

--- a/app/src/main/java/com/goldennova/upquest/presentation/alarmalert/AlarmAlertRoot.kt
+++ b/app/src/main/java/com/goldennova/upquest/presentation/alarmalert/AlarmAlertRoot.kt
@@ -1,0 +1,12 @@
+package com.goldennova.upquest.presentation.alarmalert
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+// TODO: Phase 9에서 구현 예정
+@Composable
+fun AlarmAlertRoot(
+    onDismiss: () -> Unit = {},
+) {
+    Text(text = "AlarmAlert — 구현 예정")
+}

--- a/app/src/main/java/com/goldennova/upquest/presentation/alarmdetail/AlarmDetailRoot.kt
+++ b/app/src/main/java/com/goldennova/upquest/presentation/alarmdetail/AlarmDetailRoot.kt
@@ -1,0 +1,14 @@
+package com.goldennova.upquest.presentation.alarmdetail
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+// TODO: Phase 7에서 구현 예정
+@Composable
+fun AlarmDetailRoot(
+    alarmId: Long = -1L,
+    onNavigateBack: () -> Unit = {},
+    onNavigateToPhotoSetup: (Long) -> Unit = {},
+) {
+    Text(text = "AlarmDetail(alarmId=$alarmId) — 구현 예정")
+}

--- a/app/src/main/java/com/goldennova/upquest/presentation/alarmlist/AlarmListRoot.kt
+++ b/app/src/main/java/com/goldennova/upquest/presentation/alarmlist/AlarmListRoot.kt
@@ -1,0 +1,13 @@
+package com.goldennova.upquest.presentation.alarmlist
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+// TODO: Phase 6에서 구현 예정
+@Composable
+fun AlarmListRoot(
+    onNavigateToNewAlarm: () -> Unit = {},
+    onNavigateToAlarm: (Long) -> Unit = {},
+) {
+    Text(text = "AlarmList — 구현 예정")
+}

--- a/app/src/main/java/com/goldennova/upquest/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/goldennova/upquest/presentation/navigation/AppNavHost.kt
@@ -1,0 +1,76 @@
+package com.goldennova.upquest.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.toRoute
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.goldennova.upquest.presentation.alarmalert.AlarmAlertRoot
+import com.goldennova.upquest.presentation.alarmdetail.AlarmDetailRoot
+import com.goldennova.upquest.presentation.alarmlist.AlarmListRoot
+import com.goldennova.upquest.presentation.photosetup.PhotoSetupRoot
+import com.goldennova.upquest.presentation.settings.SettingsRoot
+
+@Composable
+fun AppNavHost(
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+) {
+    NavHost(
+        navController = navController,
+        startDestination = AlarmList,
+        modifier = modifier,
+    ) {
+        composable<AlarmList> {
+            AlarmListRoot(
+                onNavigateToNewAlarm = {
+                    navController.navigate(AlarmDetail())
+                },
+                onNavigateToAlarm = { alarmId ->
+                    navController.navigate(AlarmDetail(alarmId = alarmId))
+                },
+            )
+        }
+
+        composable<AlarmDetail> { backStackEntry ->
+            val route = backStackEntry.toRoute<AlarmDetail>()
+            AlarmDetailRoot(
+                alarmId = route.alarmId,
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
+                onNavigateToPhotoSetup = { alarmId ->
+                    navController.navigate(PhotoSetup(alarmId = alarmId))
+                },
+            )
+        }
+
+        composable<AlarmAlert> {
+            AlarmAlertRoot(
+                onDismiss = {
+                    navController.popBackStack()
+                },
+            )
+        }
+
+        composable<PhotoSetup> { backStackEntry ->
+            val route = backStackEntry.toRoute<PhotoSetup>()
+            PhotoSetupRoot(
+                alarmId = route.alarmId,
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
+            )
+        }
+
+        composable<Settings> {
+            SettingsRoot(
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/goldennova/upquest/presentation/navigation/Route.kt
+++ b/app/src/main/java/com/goldennova/upquest/presentation/navigation/Route.kt
@@ -1,0 +1,19 @@
+package com.goldennova.upquest.presentation.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+object AlarmList
+
+// alarmId = -1 : 신규 생성, 그 외 : 기존 알람 수정
+@Serializable
+data class AlarmDetail(val alarmId: Long = -1L)
+
+@Serializable
+object AlarmAlert
+
+@Serializable
+data class PhotoSetup(val alarmId: Long)
+
+@Serializable
+object Settings

--- a/app/src/main/java/com/goldennova/upquest/presentation/photosetup/PhotoSetupRoot.kt
+++ b/app/src/main/java/com/goldennova/upquest/presentation/photosetup/PhotoSetupRoot.kt
@@ -1,0 +1,13 @@
+package com.goldennova.upquest.presentation.photosetup
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+// TODO: Phase 8에서 구현 예정
+@Composable
+fun PhotoSetupRoot(
+    alarmId: Long,
+    onNavigateBack: () -> Unit = {},
+) {
+    Text(text = "PhotoSetup(alarmId=$alarmId) — 구현 예정")
+}

--- a/app/src/main/java/com/goldennova/upquest/presentation/settings/SettingsRoot.kt
+++ b/app/src/main/java/com/goldennova/upquest/presentation/settings/SettingsRoot.kt
@@ -1,0 +1,12 @@
+package com.goldennova.upquest.presentation.settings
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+// TODO: Phase 11에서 구현 예정
+@Composable
+fun SettingsRoot(
+    onNavigateBack: () -> Unit = {},
+) {
+    Text(text = "Settings — 구현 예정")
+}

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -387,44 +387,6 @@ enum class ThemeMode { LIGHT, DARK, SYSTEM }
 
 ---
 
-## Phase 5-5. 권한 관리 인프라
-
-### 5-5-a. PermissionStatus sealed class 정의
-
-`presentation/permission/PermissionStatus.kt`
-```kotlin
-sealed interface PermissionStatus {
-    data object Granted : PermissionStatus
-    data object Denied : PermissionStatus           // 거부 (재요청 가능)
-    data object PermanentlyDenied : PermissionStatus // 영구 거부 ("다시 묻지 않음" 선택)
-}
-```
-
-### 5-5-b. PermissionRationaleDialog 공용 컴포저블 작성
-
-`presentation/components/PermissionRationaleDialog.kt`
-- 권한이 필요한 이유를 설명하는 다이얼로그.
-- "허용" 버튼 → 권한 재요청 람다 호출.
-- "취소" 버튼 → 다이얼로그 닫기.
-- 파라미터: `title`, `description`, `onConfirm`, `onDismiss`.
-
-### 5-5-c. PermissionSettingsDialog 공용 컴포저블 작성
-
-`presentation/components/PermissionSettingsDialog.kt`
-- 영구 거부 시 앱 설정으로 유도하는 다이얼로그.
-- "설정으로 이동" 버튼 → `Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)` 실행.
-- "취소" 버튼 → 다이얼로그 닫기 및 해당 기능 비활성화 안내.
-- 파라미터: `title`, `description`, `onGoToSettings`, `onDismiss`.
-
-### 5-5-d. PermissionDialog UI 테스트
-
-`androidTest/.../components/PermissionRationaleDialogTest.kt`
-`androidTest/.../components/PermissionSettingsDialogTest.kt`
-- 각 버튼 클릭 시 람다 호출 검증.
-- 텍스트 렌더링 검증.
-
----
-
 ## Phase 6. 알람 리스트 화면
 
 ### 6-a. UiState / Event / SideEffect 정의


### PR DESCRIPTION
## Summary

<!-- 변경 사항을 간략히 설명해주세요 -->
- `Route.kt` — Type-safe Navigation용 Route 5종 정의 (`@Serializable`)
  - `AlarmList`, `AlarmDetail(alarmId)`, `AlarmAlert`, `PhotoSetup(alarmId)`, `Settings`
  - `AlarmDetail(alarmId = -1L)` 기본값으로 신규 생성 / 수정 분기 처리
- `AppNavHost.kt` — `NavHost`에 전체 Route 등록, `navController` 내부 캡슐화
- 각 화면 패키지에 Root 컴포저블 스텁 생성 (Phase 6~11에서 순차 교체 예정)
- `MainActivity` — 임시 플레이스홀더를 `AppNavHost`로 교체

## Related Issue

Closes #10 

## Test plan

- [x] `./gradlew assembleDevDebug` 빌드 성공 확인
- [x] 앱 실행 시 `AlarmList` 화면이 시작 목적지로 표시되는지 확인

## Notes

<!-- 리뷰어에게 전달할 참고 사항 (선택) -->
- `Scaffold`는 `AppNavHost`가 아닌 각 화면의 Root에서 개별 관리
    (TopAppBar·FAB 구성이 화면마다 다르기 때문)
- `navController`는 `AppNavHost` 내부에 보유하며 Root 컴포저블에는 람다만 전달
    (Root가 NavController에 직접 의존하지 않도록 분리)